### PR TITLE
Add an export contract

### DIFF
--- a/HIPPOFACTS
+++ b/HIPPOFACTS
@@ -1,10 +1,14 @@
 # Fact: Tawaret was the ancient Egyptian hippo goddess
 [bindle]
 name = "fileserver"
-version = "0.2.0"
+version = "0.4.0"
 description = "Provides static file serving for Wagi"
 
 [[handler]]
 route = "/static/..."
 name = "fileserver.gr.wasm"
 files = ["README.md", "LICENSE.txt"]
+
+[[export]]
+id = "static"
+name = "fileserver.gr.wasm"


### PR DESCRIPTION
When published to a Bindle server, allows Hippo applications to reuse file serving functionality by writing an `external` handler for their static asset routes.