### PR TITLE
Upgrade to Grain 0.4

### DIFF
--- a/.github/workflows/grain.yml
+++ b/.github/workflows/grain.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: engineerd/configurator@v0.0.8
         with:
           name: "grain"
-          url: "https://github.com/grain-lang/grain/releases/download/grain-v0.4.2/grain-linux-x64"
+          url: "https://github.com/grain-lang/grain/releases/download/grain-v0.4.3/grain-linux-x64"
       - uses: engineerd/configurator@v0.0.8
         with:
           name: "wasmtime"

--- a/.github/workflows/grain.yml
+++ b/.github/workflows/grain.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: engineerd/configurator@v0.0.8
         with:
           name: "grain"
-          url: "https://github.com/grain-lang/grain/releases/download/grain-v0.3.2/grain-linux-x64"
+          url: "https://github.com/grain-lang/grain/releases/download/grain-v0.4.2/grain-linux-x64"
       - uses: engineerd/configurator@v0.0.8
         with:
           name: "wasmtime"

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,9 @@ doc: lib/*.gr
 	grain doc lib/mediatype.gr -o lib/mediatype.md
 	grain doc lib/stringutil.gr -o lib/stringutil.md
 
-fmt: fileserver.gr lib/*.gr
+fmt: *.gr lib/*.gr
 	grain format fileserver.gr --in-place
+	grain format tests.gr --in-place
 	grain format lib/env.gr --in-place
 	grain format lib/mediatype.gr --in-place
 	grain format lib/stringutil.gr --in-place

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,8 @@ test:
 .PHONY: push
 push:
 	hippofactory -s ${BINDLE_SERVER_URL} .
+
+doc: lib/*.gr
+	grain doc lib/env.gr -o lib/env.md
+	grain doc lib/mediatype.gr -o lib/mediatype.md
+	grain doc lib/stringutil.gr -o lib/stringutil.md

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,9 @@ doc: lib/*.gr
 	grain doc lib/env.gr -o lib/env.md
 	grain doc lib/mediatype.gr -o lib/mediatype.md
 	grain doc lib/stringutil.gr -o lib/stringutil.md
+
+fmt: fileserver.gr lib/*.gr
+	grain format fileserver.gr --in-place
+	grain format lib/env.gr --in-place
+	grain format lib/mediatype.gr --in-place
+	grain format lib/stringutil.gr --in-place

--- a/fileserver.gr
+++ b/fileserver.gr
@@ -5,45 +5,41 @@ import Map from "map"
 import Option from "option"
 import File from "sys/file"
 import String from "string"
+import Result from "result"
 import Mediatype from "./lib/mediatype"
 import Stringutil from "./lib/stringutil"
 
+// Utility wrapper around a Result.expect that ignores the return value
+// so we don't need to worry about things returning non-Void types
+let validateResult = (msg, res) => {
+  ignore(Result.expect(msg, res))
+}
+
 let internalError = () => {
-  // Is stdout correct here?
-  let result = File.fdWrite(File.stdout, "Status: 500\n\nInternal Server Error")
-  match (result) {
-    Err(err) => {
-      // TODO: What do you do on a write error?
-      void
-    },
-    Ok(_nBytes) => void,
-  }
+  validateResult(
+    "Unexpected error when writing Internal Server Error response",
+    File.fdWrite(File.stdout, "Status: 500\n\nInternal Server Error"),
+  )
 }
 
 let notFound = () => {
-  let result = File.fdWrite(File.stdout, "Status: 404\n\nNot Found")
-  match (result) {
-    Err(err) => {
-      // TODO: What do you do on a write error?
-      void
-    },
-    Ok(_nBytes) => void,
-  }
+  validateResult(
+    "Unexpected error when writing Not Found response",
+    File.fdWrite(File.stdout, "Status: 404\n\nNot Found"),
+  )
 }
 
 // Pipe output to STDOUT
 let rec pipe = (in, out) => {
   let res = File.fdRead(in, 1024)
   match (res) {
-    Err(err) => {
-      // TODO: What to do on a read error?
-      void
-    },
+    Err(err) => Err(err),
     Ok((d, len)) => {
-      // TODO: What should happen if this Result is an error
-      File.fdWrite(out, d)
+      let res = File.fdWrite(out, d)
       if (len > 0) {
         pipe(in, out)
+      } else {
+        res
       }
     },
   }
@@ -52,10 +48,9 @@ let rec pipe = (in, out) => {
 let serve = abs_path => {
   // Trim the leading /
   let path = String.slice(1, String.length(abs_path), abs_path)
-  // TODO: What should happen if any of these Results are an error
-  File.fdWrite(File.stderr, "Fileserver: Loading file ")
-  File.fdWrite(File.stderr, path)
-  File.fdWrite(File.stderr, "\n")
+  // Explicitly ignoring any Ok or Err that happens on this log
+  // The `ignore` can be removed if you don't want to be explicit about this behavior
+  ignore(File.fdWrite(File.stderr, "Fileserver: Loading file " ++ path ++ "\n"))
 
   // Open file
   let result = File.pathOpen(File.pwdfd, [], path, [], [File.FdRead], [], [])
@@ -63,15 +58,20 @@ let serve = abs_path => {
   match (result) {
     Err(_err) => notFound(),
     Ok(input) => {
-      // TODO: What should happen if any of these Results are an error
-      File.fdWrite(File.stdout, "Content-Type: ")
-      File.fdWrite(File.stdout, Mediatype.guess(path))
-      File.fdWrite(File.stdout, "\n\n")
+      validateResult(
+        "Unexpected error when writing Content-Type",
+        File.fdWrite(
+          File.stdout,
+          "Content-Type: " ++ Mediatype.guess(path) ++ "\n\n",
+        ),
+      )
 
-      pipe(input, File.stdout)
-      // TODO: What should happen if this Result is an error
-      File.fdClose(input)
-      void
+      validateResult(
+        "Unexpected error when streaming file body",
+        pipe(input, File.stdout),
+      )
+      // This validation may be able to be removed if it doesn't matter if the fdClose fails
+      validateResult("Unexpected error when closing file", File.fdClose(input))
     },
   }
 }

--- a/fileserver.gr
+++ b/fileserver.gr
@@ -8,59 +8,83 @@ import String from "string"
 import Mediatype from "./lib/mediatype"
 import Stringutil from "./lib/stringutil"
 
-let serve = (abs_path) => {
-    // Trim the leading /
-    let path = String.slice(1, String.length(abs_path), abs_path)
-    File.fdWrite(File.stderr, "Fileserver: Loading file ")
-    File.fdWrite(File.stderr, path)
-    File.fdWrite(File.stderr, "\n")
-
-    // Open file
-    // TODO: This throws an error when something goes wrong.
-    // But Grain 0.3 does not have a try/catch yet.
-    // When we figure out how, we need to catch the error here
-    // and do a 404 or 500.
-    let input = File.pathOpen(
-        File.pwdfd,
-        [],
-        path,
-        [],
-        [File.FdRead],
-        [],
-        [],   
-    )
-
-    File.fdWrite(File.stdout, "Content-Type: ")
-    File.fdWrite(File.stdout, Mediatype.guess(path))
-    File.fdWrite(File.stdout, "\n\n")
-    
-    // Pipe output to STDOUT
-    let rec pipe = (in, out) => {
-        let (d, len) = File.fdRead(in, 1024)
-        File.fdWrite(out, d)
-        if (len > 0) {
-            pipe(in, out)
-        }
-    }
-    pipe(input, File.stdout)
-    File.fdClose(input)
-}
-
-let guestpath = (env) => {
-
-    // Backward compat for an older version of Wagi that had PATH_INFO wrong.
-    // X_RELATIVE_PATH was removed before Wagi 0.4
-    match (Map.get("X_RELATIVE_PATH", env)) {
-        Some(p) => String.concat("/", p),
-        None => {
-            Option.unwrap(Map.get("PATH_INFO", env))
-        }
-    }
-    
+let internalError = () => {
+  // Is stdout correct here?
+  let result = File.fdWrite(File.stdout, "Status: 500\n\nInternal Server Error")
+  match (result) {
+    Err(err) => {
+      // TODO: What do you do on a write error?
+      void
+    },
+    Ok(_nBytes) => void,
+  }
 }
 
 let notFound = () => {
-    File.fdWrite(File.stdout, "Status: 404\n\nNot Found")
+  let result = File.fdWrite(File.stdout, "Status: 404\n\nNot Found")
+  match (result) {
+    Err(err) => {
+      // TODO: What do you do on a write error?
+      void
+    },
+    Ok(_nBytes) => void,
+  }
+}
+
+// Pipe output to STDOUT
+let rec pipe = (in, out) => {
+  let res = File.fdRead(in, 1024)
+  match (res) {
+    Err(err) => {
+      // TODO: What to do on a read error?
+      void
+    },
+    Ok((d, len)) => {
+      // TODO: What should happen if this Result is an error
+      File.fdWrite(out, d)
+      if (len > 0) {
+        pipe(in, out)
+      }
+    },
+  }
+}
+
+let serve = abs_path => {
+  // Trim the leading /
+  let path = String.slice(1, String.length(abs_path), abs_path)
+  // TODO: What should happen if any of these Results are an error
+  File.fdWrite(File.stderr, "Fileserver: Loading file ")
+  File.fdWrite(File.stderr, path)
+  File.fdWrite(File.stderr, "\n")
+
+  // Open file
+  let result = File.pathOpen(File.pwdfd, [], path, [], [File.FdRead], [], [])
+
+  match (result) {
+    Err(_err) => notFound(),
+    Ok(input) => {
+      // TODO: What should happen if any of these Results are an error
+      File.fdWrite(File.stdout, "Content-Type: ")
+      File.fdWrite(File.stdout, Mediatype.guess(path))
+      File.fdWrite(File.stdout, "\n\n")
+
+      pipe(input, File.stdout)
+      // TODO: What should happen if this Result is an error
+      File.fdClose(input)
+      void
+    },
+  }
+}
+
+let guestpath = env => {
+  // Backward compat for an older version of Wagi that had PATH_INFO wrong.
+  // X_RELATIVE_PATH was removed before Wagi 0.4
+  match (Map.get("X_RELATIVE_PATH", env)) {
+    Some(p) => String.concat("/", p),
+    None => {
+      Option.unwrap(Map.get("PATH_INFO", env))
+    },
+  }
 }
 
 let kv = Env.envMap()

--- a/lib/env.gr
+++ b/lib/env.gr
@@ -4,33 +4,44 @@ import Array from "array"
 import String from "string"
 import Option from "option"
 
-// Split an environment variable at the first equals sign.
-// @param item: An environment variable pair, separated by an equals sign (=).
-// @return (String, String) A tuple key/value pair.
-export let splitEnvVar = (item) => {
-    let offsetOpt = String.indexOf("=", item)
+/**
+ * Split an environment variable at the first equals sign.
+ *
+ * @param item: An environment variable pair, separated by an equals sign (=).
+ * @returns A tuple key/value pair.
+ */
+export let splitEnvVar = item => {
+  let offsetOpt = String.indexOf("=", item)
 
-    // For now, fail if the env var is malformed.
-    let offset = Option.unwrap(offsetOpt)
+  // For now, fail if the env var is malformed.
+  let offset = Option.unwrap(offsetOpt)
 
-    let key = String.slice(0, offset, item)
-    let val = String.slice(offset+1, String.length(item), item)
-    (key, val)
+  let key = String.slice(0, offset, item)
+  let val = String.slice(offset + 1, String.length(item), item)
+  (key, val)
 }
 
-// Get the environment variables as a Map<String, String>
-//
-// @return Map<String, String> A map of all environment variables.
-export let envMap = () =>  {
-    let parsed = Map.make()
-    let env = Process.env()
-    let pairs = Array.map(splitEnvVar,env)
+/**
+ * Get the environment variables as a Map<String, String>
+ *
+ * @returns A map of all environment variables.
+ */
+export let envMap = () => {
+  let parsed = Map.make()
+  let env = Process.env()
+  match (env) {
+    Err(err) => parsed,
+    Ok(env) => {
+      let pairs = Array.map(splitEnvVar, env)
 
-    Array.forEach((item) => {
-        let (k, v) = item
-        Map.set(k, v, parsed)
-    }, pairs)
-    parsed
+      Array.forEach(
+        item => {
+          let (k, v) = item
+          Map.set(k, v, parsed)
+        },
+        pairs,
+      )
+      parsed
+    },
+  }
 }
-
-

--- a/lib/env.md
+++ b/lib/env.md
@@ -1,0 +1,34 @@
+### Env.**splitEnvVar**
+
+```grain
+splitEnvVar : String -> (String, String)
+```
+
+Split an environment variable at the first equals sign.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`item`|`String`|An environment variable pair, separated by an equals sign (=).|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`(String, String)`|A tuple key/value pair.|
+
+### Env.**envMap**
+
+```grain
+envMap : () -> Map.Map<a, b>
+```
+
+Get the environment variables as a Map<String, String>
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Map.Map<a, b>`|A map of all environment variables.|
+

--- a/lib/mediatype.gr
+++ b/lib/mediatype.gr
@@ -2,7 +2,7 @@ import String from "string"
 import Array from "array"
 import Option from "option"
 import Map from "map"
-import {lastIndexOf, reverse} from "./lib/stringutil"
+import { lastIndexOf, reverse } from "./stringutil"
 
 export let default_mt = "application/octet-stream"
 
@@ -82,18 +82,30 @@ Map.set("7z", "application/x-7z-compressed", mediatypes)
 Map.set("azw", "application/vnd.amazon.ebook", mediatypes)
 Map.set("bin", "application/octet-stream", mediatypes)
 Map.set("doc", "application/msword", mediatypes)
-Map.set("docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", mediatypes)
+Map.set(
+  "docx",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  mediatypes,
+)
 Map.set("epub", "application/epub+zip", mediatypes)
 Map.set("odp", "application/vnd.oasis.opendocument.presentation", mediatypes)
 Map.set("ods", "application/vnd.oasis.opendocument.spreadsheet", mediatypes)
 Map.set("odt", "application/vnd.oasis.opendocument.text", mediatypes)
 Map.set("pdf", "application/pdf", mediatypes)
 Map.set("ppt", "application/vnd.ms-powerpoint", mediatypes)
-Map.set("pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation", mediatypes)
+Map.set(
+  "pptx",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  mediatypes,
+)
 Map.set("rtf", "application/rtf", mediatypes)
 Map.set("vsd", "application/vnd.visio", mediatypes)
 Map.set("xls", "application/vnd.ms-excel", mediatypes)
-Map.set("xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", mediatypes)
+Map.set(
+  "xlsx",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  mediatypes,
+)
 
 // Fonts
 Map.set("eot", "application/vnd.ms-fontobject", mediatypes)
@@ -102,19 +114,21 @@ Map.set("ttf", "font/ttf", mediatypes)
 Map.set("woff", "font/woff", mediatypes)
 Map.set("woff2", "font/woff2", mediatypes)
 
-// Guess the media type of this file
-//
-// Per recommendation, if no media type is found for an extension,
-// this returns `application/octet-stream`.
-//
-// @param filename: The name of the file
-// @returns String a media type
+/**
+ * Guess the media type of this file
+ *
+ * Per recommendation, if no media type is found for an extension,
+ * this returns `application/octet-stream`.
+ *
+ * @param filename: The name of the file
+ * @returns A media type
+ */
 export let guess = (filename: String) => {
-    match (lastIndexOf(".", filename)) {
-        Some(extOffset) => {
-            let ext = String.slice(extOffset + 1, String.length(filename), filename)
-            Option.unwrapWithDefault(default_mt, Map.get(ext, mediatypes))
-        },
-        None => default_mt
-    }
+  match (lastIndexOf(".", filename)) {
+    Some(extOffset) => {
+      let ext = String.slice(extOffset + 1, String.length(filename), filename)
+      Option.unwrapWithDefault(default_mt, Map.get(ext, mediatypes))
+    },
+    None => default_mt,
+  }
 }

--- a/lib/mediatype.md
+++ b/lib/mediatype.md
@@ -1,0 +1,29 @@
+### Mediatype.**default_mt**
+
+```grain
+default_mt : String
+```
+
+### Mediatype.**guess**
+
+```grain
+guess : String -> String
+```
+
+Guess the media type of this file
+
+Per recommendation, if no media type is found for an extension,
+this returns `application/octet-stream`.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`filename`|`String`|The name of the file|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`String`|A media type|
+

--- a/lib/stringutil.gr
+++ b/lib/stringutil.gr
@@ -1,50 +1,50 @@
 import String from "string"
 import Array from "array"
 
-// Return a String that is the reverse of the given String.
-//
-// @param str: The string to reverse.
-// @return String A reversed version of the given string
+/**
+ * Return a String that is the reverse of the given String.
+ *
+ * @param str: The string to reverse.
+ * @returns A reversed version of the given string
+ */
 export let reverse = (str: String) => {
-    let chars = String.explode(str)
-    let clen = Array.length(chars)
-    let rev = Array.init(clen, (index) => {
-        let last = clen - index - 1
-        chars[last]
-    })
-    String.implode(rev)
+  let chars = String.explode(str)
+  let rev = Array.reverse(chars)
+  String.implode(rev)
 }
 
-// Get the index of the last appearance of needle in the haystack.
-//
-// For a multi-character needle, this will return the end of that sequence,
-// not the beginning (as indexOf does).
-//
-// @param needle: The string to search for
-// @param haystack: The string to be searched
-// @return Option<Number> The offset, if found, or a number
+/**
+ * Get the index of the last appearance of needle in the haystack.
+ *
+ * For a multi-character needle, this will return the end of that sequence,
+ * not the beginning (as indexOf does).
+ *
+ * @param needle: The string to search for
+ * @param haystack: The string to be searched
+ * @returns The offset, if found, or a number
+ */
 export let lastIndexOf = (needle: String, haystack: String) => {
-    let rev = reverse(haystack)
-    let revNeedle = reverse(needle)
-    let nlen = String.length(needle)
-    let i = String.indexOf(revNeedle, rev)
-    match (i) {
-        Some(offset) => Some(String.length(haystack) - 1 - offset),
-        None => None,   
-    }
+  let rev = reverse(haystack)
+  let revNeedle = reverse(needle)
+  let nlen = String.length(needle)
+  let i = String.indexOf(revNeedle, rev)
+  match (i) {
+    Some(offset) => Some(((String.length(haystack)) - 1) - offset),
+    None => None,
+  }
 }
 
 export let afterLast = (needle: String, haystack: String) => {
-    match (lastIndexOf(needle, haystack)) {
-        Some(index) => String.slice(index + 1, String.length(haystack), haystack),
-        None => haystack
-    }
+  match (lastIndexOf(needle, haystack)) {
+    Some(index) => String.slice(index + 1, String.length(haystack), haystack),
+    None => haystack,
+  }
 }
 
 export let beforeLast = (needle: String, haystack: String) => {
-    let nlen = String.length(needle)
-    match (lastIndexOf(needle, haystack)) {
-        Some(index) => String.slice(0, index + 1 - nlen, haystack),
-        None => haystack
-    }
+  let nlen = String.length(needle)
+  match (lastIndexOf(needle, haystack)) {
+    Some(index) => String.slice(0, (index + 1) - nlen, haystack),
+    None => haystack,
+  }
 }

--- a/lib/stringutil.gr
+++ b/lib/stringutil.gr
@@ -29,7 +29,7 @@ export let lastIndexOf = (needle: String, haystack: String) => {
   let nlen = String.length(needle)
   let i = String.indexOf(revNeedle, rev)
   match (i) {
-    Some(offset) => Some(((String.length(haystack)) - 1) - offset),
+    Some(offset) => Some(String.length(haystack) - 1 - offset),
     None => None,
   }
 }
@@ -44,7 +44,7 @@ export let afterLast = (needle: String, haystack: String) => {
 export let beforeLast = (needle: String, haystack: String) => {
   let nlen = String.length(needle)
   match (lastIndexOf(needle, haystack)) {
-    Some(index) => String.slice(0, (index + 1) - nlen, haystack),
+    Some(index) => String.slice(0, index + 1 - nlen, haystack),
     None => haystack,
   }
 }

--- a/lib/stringutil.md
+++ b/lib/stringutil.md
@@ -1,0 +1,56 @@
+### Stringutil.**reverse**
+
+```grain
+reverse : String -> String
+```
+
+Return a String that is the reverse of the given String.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`str`|`String`|The string to reverse.|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`String`|A reversed version of the given string|
+
+### Stringutil.**lastIndexOf**
+
+```grain
+lastIndexOf : (String, String) -> Option<Number>
+```
+
+Get the index of the last appearance of needle in the haystack.
+
+For a multi-character needle, this will return the end of that sequence,
+not the beginning (as indexOf does).
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`needle`|`String`|The string to search for|
+|`haystack`|`String`|The string to be searched|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Option<Number>`|The offset, if found, or a number|
+
+### Stringutil.**afterLast**
+
+```grain
+afterLast : (String, String) -> String
+```
+
+### Stringutil.**beforeLast**
+
+```grain
+beforeLast : (String, String) -> String
+```
+

--- a/tests.gr
+++ b/tests.gr
@@ -10,7 +10,7 @@ let mut totalErr = 0
 let check = (a, b, msg: String) => {
   match (a == b) {
     true => Ok(String.concat("✅ PASS\t\t", msg)),
-    _ => {
+    false => {
       totalErr += 1
       print("===== Expected: =====")
       print(a)

--- a/tests.gr
+++ b/tests.gr
@@ -9,7 +9,7 @@ let mut totalErr = 0
 
 let check = (a, b, msg: String) => {
   match (a == b) {
-    true => Ok(String.concat("\226\156\133 PASS\t\t", msg)),
+    true => Ok(String.concat("✅ PASS\t\t", msg)),
     _ => {
       totalErr += 1
       print("===== Expected: =====")
@@ -17,7 +17,7 @@ let check = (a, b, msg: String) => {
       print("======= Got: ========")
       print(b)
       print("=====================")
-      Err(String.concat("\226\155\148\239\184\143 FAIL\t\t", msg))
+      Err(String.concat("⛔️ FAIL\t\t", msg))
     },
   }
 }

--- a/tests.gr
+++ b/tests.gr
@@ -8,46 +8,83 @@ import Mediatype from "./lib/mediatype"
 let mut totalErr = 0
 
 let check = (a, b, msg: String) => {
-    match (a == b) {
-        true => Ok(String.concat("✅ PASS\t\t", msg)),
-        _  => {
-            totalErr += 1
-            print("===== Expected: =====")
-            print(a)
-            print("======= Got: ========")
-            print(b)
-            print("=====================")
-            Err(String.concat("⛔️ FAIL\t\t", msg))
-        }
-    }
+  match (a == b) {
+    true => Ok(String.concat("\226\156\133 PASS\t\t", msg)),
+    _ => {
+      totalErr += 1
+      print("===== Expected: =====")
+      print(a)
+      print("======= Got: ========")
+      print(b)
+      print("=====================")
+      Err(String.concat("\226\155\148\239\184\143 FAIL\t\t", msg))
+    },
+  }
 }
 
 let expect = (a, b, msg: String) => {
-    match (check(a, b, msg)) {
-        Ok(yay) => print(yay),
-        Err(e) => print(e)
-    }
+  match (check(a, b, msg)) {
+    Ok(yay) => print(yay),
+    Err(e) => print(e),
+  }
 }
 
 let report = () => {
-    if (totalErr > 0) {
-        File.fdWrite(File.stderr, "❌ Total failed tests: ")
-        File.fdWrite(File.stderr, toString(totalErr))
-        File.fdWrite(File.stderr, "❌\n")
-        Process.exit(1)
-    }
+  if (totalErr > 0) {
+    File.fdWrite(File.stderr, "\226\157\140 Total failed tests: ")
+    File.fdWrite(File.stderr, toString(totalErr))
+    File.fdWrite(File.stderr, "\226\157\140\n")
+    Process.exit(1)
+    void
+  }
 }
 
 expect(("a", "b"), Env.splitEnvVar("a=b"), "Env.splitEnvVar should parse")
 expect("gfedcba", Util.reverse("abcdefg"), "Util.reverse should reverse string")
-expect(Some(5), Util.lastIndexOf("/.", "aaaa/."), "Util.lastIndexOf should find Some")
-expect(Some(18), Util.lastIndexOf(".", "aaaa/fileserver.gr.wasm"), "Util.lastIndexOf should find last dot, not first dot")
-expect(Some(12), Util.lastIndexOf(".", "/.../aaaa/..."), "Util.lastIndexOf should find last set of three dots")
-expect(None, Util.lastIndexOf("??", "aaaa.."), "Util.lastIndexOf should find None")
-expect("test", Util.afterLast("$.$", "foo$.$bar$.$test"), "Util.afterLast should find last match")
-expect("/prefix/../path", Util.beforeLast("/..", "/prefix/../path/.."), "Util.beforeLast should return first part")
-expect("/prefix/../path/..", Util.beforeLast("/$$", "/prefix/../path/.."), "Util.beforeLast should return entire string when no match")
-expect("text/plain", Mediatype.guess("foo.txt"), "Mediatype.guess should find text/plain")
-expect("application/octet-stream", Mediatype.guess("foo.MADEUP"), "Mediatype.guess should find default type")
+expect(
+  Some(5),
+  Util.lastIndexOf("/.", "aaaa/."),
+  "Util.lastIndexOf should find Some",
+)
+expect(
+  Some(18),
+  Util.lastIndexOf(".", "aaaa/fileserver.gr.wasm"),
+  "Util.lastIndexOf should find last dot, not first dot",
+)
+expect(
+  Some(12),
+  Util.lastIndexOf(".", "/.../aaaa/..."),
+  "Util.lastIndexOf should find last set of three dots",
+)
+expect(
+  None,
+  Util.lastIndexOf("??", "aaaa.."),
+  "Util.lastIndexOf should find None",
+)
+expect(
+  "test",
+  Util.afterLast("$.$", "foo$.$bar$.$test"),
+  "Util.afterLast should find last match",
+)
+expect(
+  "/prefix/../path",
+  Util.beforeLast("/..", "/prefix/../path/.."),
+  "Util.beforeLast should return first part",
+)
+expect(
+  "/prefix/../path/..",
+  Util.beforeLast("/$$", "/prefix/../path/.."),
+  "Util.beforeLast should return entire string when no match",
+)
+expect(
+  "text/plain",
+  Mediatype.guess("foo.txt"),
+  "Mediatype.guess should find text/plain",
+)
+expect(
+  "application/octet-stream",
+  Mediatype.guess("foo.MADEUP"),
+  "Mediatype.guess should find default type",
+)
 
 report()

--- a/tests.gr
+++ b/tests.gr
@@ -31,9 +31,9 @@ let expect = (a, b, msg: String) => {
 
 let report = () => {
   if (totalErr > 0) {
-    File.fdWrite(File.stderr, "\226\157\140 Total failed tests: ")
+    File.fdWrite(File.stderr, "❌ Total failed tests: ")
     File.fdWrite(File.stderr, toString(totalErr))
-    File.fdWrite(File.stderr, "\226\157\140\n")
+    File.fdWrite(File.stderr, "❌\n")
     Process.exit(1)
     void
   }


### PR DESCRIPTION
Grain 0.4 converted all of the WASI functions from throwing exceptions to returning a `Result` type. This is a preliminary conversion from Grain 0.3.2 to 0.4.2.

There are a bunch of `TODO` comments asking what should happen if a Result is an `Err` type. I can make the changes if I know what should happen.

This version of Grain also added automatic code formatting, so a lot of the diff is that being applied. I also changed the graindoc style and added a make task to generate markdown documentation for everything in `lib`. (I'm bad with make, so I'm not sure this is the written the best way)