### PR TITLE
Add support for PATH_PREFIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ SOFTWARE
 
 The fileserver took `/static/filserver.gr`, removed the `/static/` part from the front, and then loaded `fileserver.gr` from the directory mounted in the `modules.toml`. Note that any subdirectories are also served. So `/static/foo/bar` would translate to the path `foo/bar` inside of the WebAssembly module (which in the example above would fully resolve to "/path/to/fileserver/foo/bar").
 
+## Prefiing a Path
+
+`PATH_PREFIX` is an environment variable you can set.
+This allows you to add `-e PATH_PREFIX=/some/prefix` as an env var to `fileserver.gr.wasm`.
+
+This will allow the fileserver to set a specific path prefix for files before it looks them up. So instead of doing `http://example.com/static/static/foo.png`, you can set `wagi -e PATH_PREFIX=static/` and then `http://example.com/static/foo.png` will resolve on the filesystem, to `static/foo.png` instead of `foo.png`.
+
 ## Security Note
 
 The Wagi fileserver is designed to serve any file mounted in the volume. Do not mount a

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ SOFTWARE
 
 The fileserver took `/static/filserver.gr`, removed the `/static/` part from the front, and then loaded `fileserver.gr` from the directory mounted in the `modules.toml`. Note that any subdirectories are also served. So `/static/foo/bar` would translate to the path `foo/bar` inside of the WebAssembly module (which in the example above would fully resolve to "/path/to/fileserver/foo/bar").
 
-## Prefiing a Path
+## Prefixing a Path
 
 `PATH_PREFIX` is an environment variable you can set.
 This allows you to add `-e PATH_PREFIX=/some/prefix` as an env var to `fileserver.gr.wasm`.

--- a/fileserver.gr
+++ b/fileserver.gr
@@ -45,9 +45,17 @@ let rec pipe = (in, out) => {
   }
 }
 
-let serve = abs_path => {
-  // Trim the leading /
-  let path = String.slice(1, String.length(abs_path), abs_path)
+let serve = (abs_path, env) => {
+  // If PATH_PREFIX is set, then the path prefix is prepended onto the incoming path.
+  // This allows you to map to a directory that does not match the directory name in the URL.
+  let path = match (Map.get("PATH_PREFIX", env)) {
+    Some(prefix) => {
+      let tmp = String.slice(1, String.length(abs_path), abs_path)
+      String.concat(prefix, tmp)
+    },
+    // If no env var, trim off just the leading /
+    None => String.slice(1, String.length(abs_path), abs_path)
+  }
   // Explicitly ignoring any Ok or Err that happens on this log
   // The `ignore` can be removed if you don't want to be explicit about this behavior
   ignore(File.fdWrite(File.stderr, "Fileserver: Loading file " ++ path ++ "\n"))
@@ -89,4 +97,4 @@ let guestpath = env => {
 
 let kv = Env.envMap()
 let pathInfo = guestpath(kv)
-serve(pathInfo)
+serve(pathInfo, kv)


### PR DESCRIPTION
This allows you to add `-e PATH_PREFIX=/some/prefix` as an env var to `fileserver.gr.wasm`.

This will allow the fileserver to set a specific path prefix for files before it looks them up. So instead of doing `http://example.com/static/static/foo.png`, you can set `wagi -e PATH_PREFIX=static/` and then `http://example.com/static/foo.png` will resolve on the filesystem, to `static/foo.png` instead of `foo.png`.

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>